### PR TITLE
Update Team16_Project2.go

### DIFF
--- a/Team16_Project2.go
+++ b/Team16_Project2.go
@@ -427,9 +427,9 @@ func simulateInstruction(simOutput string, list []Instruction, registry []int, m
 				}
 				//*****SUB INSTRUCTION*****
 			case opcode == 1624:
-				regDest := registry[list[i].rm] - registry[list[i].rn]
+				regDest := registry[list[i].rn] - registry[list[i].rm]
 				registry[list[i].rd] = regDest
-				fmt.Fprintf(simOutputFile, "Cycle:%d\t%d\t%s\t\n", cycle, list[i].memLoc, list[i].op)
+				fmt.Fprintf(simOutputFile, "Cycle:%d\t%d\t%s R%d, R%d, R%d\n", cycle, list[i].memLoc, list[i].op, list[i].rd, list[i].rn, list[i].rm)
 				outputRegistersToFile(registry, simOutputFile, otherData)
 
 				cycle++


### PR DESCRIPTION
edited the SUBI instruction so that it prints the register number on the cycle line and that it correctly subtracts the rn from the rm instead of the opposite